### PR TITLE
refactor(auth): reduce boilerplate

### DIFF
--- a/src/app/auth/data-access/state/auth.effects.ts
+++ b/src/app/auth/data-access/state/auth.effects.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { authActions } from './auth.actions';
-import { catchError, map, of, switchMap, tap } from 'rxjs';
+import { catchError, concatMap, map, of, switchMap, tap } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { UserApiClient } from '@shared/data-access/api';
@@ -35,30 +35,25 @@ export const updateCurrentUser$ = createEffect(
   (actions$ = inject(Actions), userClient = inject(UserApiClient)) => {
     return actions$.pipe(
       ofType(authActions.updateCurrentUser),
-      switchMap(({ user }) => {
-        return userClient.update(user).pipe(
+      concatMap(({ user }) =>
+        userClient.update(user).pipe(
           map(currentUser => authActions.updateCurrentUserSuccess({ currentUser })),
           catchError((errorResponse: HttpErrorResponse) =>
             of(authActions.updateCurrentUserFailure({ errors: errorResponse.error.errors }))
           )
-        );
-      })
+        )
+      )
     );
   },
   { functional: true }
 );
 
 export const register$ = createEffect(
-  (
-    actions$ = inject(Actions),
-    userClient = inject(UserApiClient),
-    jwtService = inject(JwtService)
-  ) => {
+  (actions$ = inject(Actions), userClient = inject(UserApiClient)) => {
     return actions$.pipe(
       ofType(authActions.register),
       switchMap(({ credentials }) =>
         userClient.register(credentials).pipe(
-          tap(currentUser => jwtService.saveToken(currentUser.token)),
           map(currentUser => authActions.registerSuccess({ currentUser })),
           catchError((errorResponse: HttpErrorResponse) =>
             of(authActions.registerFailure({ errors: errorResponse.error.errors }))
@@ -70,29 +65,12 @@ export const register$ = createEffect(
   { functional: true }
 );
 
-export const registerSuccess$ = createEffect(
-  (actions$ = inject(Actions), router = inject(Router)) => {
-    return actions$.pipe(
-      ofType(authActions.registerSuccess),
-      tap(() => {
-        void router.navigateByUrl('/');
-      })
-    );
-  },
-  { functional: true, dispatch: false }
-);
-
 export const login$ = createEffect(
-  (
-    actions$ = inject(Actions),
-    userApiClient = inject(UserApiClient),
-    jwtService = inject(JwtService)
-  ) => {
+  (actions$ = inject(Actions), userApiClient = inject(UserApiClient)) => {
     return actions$.pipe(
       ofType(authActions.login),
       switchMap(({ credentials }) =>
         userApiClient.login(credentials).pipe(
-          tap(currentUser => jwtService.saveToken(currentUser.token)),
           map(currentUser => authActions.loginSuccess({ currentUser })),
           catchError((errorResponse: HttpErrorResponse) =>
             of(authActions.loginFailure({ errors: errorResponse.error.errors }))
@@ -104,11 +82,12 @@ export const login$ = createEffect(
   { functional: true }
 );
 
-export const loginSuccess$ = createEffect(
-  (actions$ = inject(Actions), router = inject(Router)) => {
+export const registerOrLoginSuccess$ = createEffect(
+  (actions$ = inject(Actions), router = inject(Router), jwtService = inject(JwtService)) => {
     return actions$.pipe(
-      ofType(authActions.loginSuccess),
-      tap(() => {
+      ofType(authActions.registerSuccess, authActions.loginSuccess),
+      tap(action => {
+        jwtService.saveToken(action.currentUser.token);
         void router.navigateByUrl('/');
       })
     );


### PR DESCRIPTION
Refactor Auth Effects

This PR includes:

- [x] use concatMap operator for updating the user
- [x] merge registerSuccess$ and loginSuccess$ into a single registerOrLoginSuccess$ effect
- [x] fix unit tests